### PR TITLE
Stop function added to stop the video streaming + small enhancements / changes

### DIFF
--- a/QRCodeScanner.razor
+++ b/QRCodeScanner.razor
@@ -7,14 +7,14 @@
 <p>Pure JavaScript QR code decoding library.</p>
 *@
 
-<div id="loadingMessage">Loading video stream (please make sure you have a camera enabled)</div>
+<div id="loadingMessage">@LoadingMessage</div>
 
 <canvas id="canvas" hidden></canvas>
 
 @if (ShowOutput)
 {
     <div id="output" hidden>
-        <div id="outputMessage">No QR code detected.</div>
+        <div id="outputMessage">@OutputMessage</div>
         <div hidden><b>Data:</b> <span id="outputData"></span></div>
     </div>
 }
@@ -22,5 +22,11 @@
  @code {
     
     [Parameter]
-    public bool ShowOutput { get; set; } = false;    
+    public bool ShowOutput { get; set; } = false;
+
+    [Parameter]
+    public string LoadingMessage { get; set; } = "Loading video stream (please make sure you have a camera enabled)";    
+
+    [Parameter]
+    public string OutputMessage { get; set; } = "No QR code detected.";        
 }

--- a/QRCodeScannerJsInterop.cs
+++ b/QRCodeScannerJsInterop.cs
@@ -22,8 +22,16 @@ namespace ReactorBlazorQRCodeScanner
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("Scanner.Init");
         }
-        
 
+        public async ValueTask StopRecording()
+        {
+            if (moduleTask.IsValueCreated)
+            {
+                var module = await moduleTask.Value;
+                await module.InvokeVoidAsync("Scanner.Stop");
+            }
+        }
+        
         private static DateTime? _lastScannedValueDateTime;
         private static int _scanInterval = 2000;
 
@@ -36,18 +44,14 @@ namespace ReactorBlazorQRCodeScanner
                 DoSomethingAboutThisQRCode(value);
             }
 
-            //Si le dernier scan est assez vieux
+            // If the last scan is old enough
             var maxDate = DateTime.Now.AddMilliseconds(-_scanInterval);
             if(_lastScannedValueDateTime < maxDate)
             {
                 _lastScannedValueDateTime = DateTime.Now;
                 DoSomethingAboutThisQRCode(value);                
             }
-            else
-            {
-                //Le dernier scan est trop récent, pour éviter d'avoir une multitude de requete a traiter on ne fait rien.
-            }
-        
+
             return Task.FromResult("retour"); //Inutile, mais bon des fois qu'on ait besoin un jour d'obtenir un retour ici...
         }
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,33 @@ On your page/componenent initialization, you need to build the QRCodeScannerJsIn
 
 When this one is Invoked, it fires the methods "OnQrCodeScan" where you can treat your QRCode data.
 
+```dotnet
+protected async Task StopQRScan()
+      {
+          await _qrCodeScannerJsInterop.StopRecording();
+      }
+```
+
+With "StopRecording" you can cancel the QR recording / video stream so that the browser will no longer use the webcam and the webcam icon in the browser (red dot) will dissapear.
+
 ### Options
 
-you can show/hide the output line that indicates the result of the QRCode when scanned. Defaut is true (visible)
+- You can show/hide the output line that indicates the result of the QRCode when scanned. Default is true (visible)
 
 ```dotnet
 <QRCodeScanner ShowOutput="false"/>
+```
+
+- You can set a custom loading message with the parameter "LoadingMessage", the default message is "Loading video stream (please make sure you have a camera enabled)".
+
+```dotnet
+<QRCodeScanner LoadingMessage="My custom loading message"/>
+```
+
+- You can set a custom output message, when no QR code is scanned, with the parameter "OutputMessage", the default message is "No QR code detected.".
+
+```dotnet
+<QRCodeScanner OutputMessage="My custom no QR code found message"/>
 ```
 
 ### TroubleShooting

--- a/ReactorBlazorQRCodeScanner.csproj
+++ b/ReactorBlazorQRCodeScanner.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <PackageId>ReactorBlazorQRCodeScanner</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>Yann Vasseur</Authors>
     <Company>reactor.fr</Company>
     <PackageTags>Blazor;Reactor;QRCode;ScannerQR Code</PackageTags>

--- a/wwwroot/qrCodeScannerJsInterop.js
+++ b/wwwroot/qrCodeScannerJsInterop.js
@@ -1,6 +1,9 @@
 import("./jsQR.js");
+var videoObject = null;
+var videoStopped = false;
 
 var Scanner = {
+
     Wait: function (ms) {
         var start = new Date().getTime();
         var end = start;
@@ -9,106 +12,134 @@ var Scanner = {
         }
     },
     QRCodeScanned: function (code) {
-
         DotNet.invokeMethodAsync("ReactorBlazorQRCodeScanner", "QRCodeJsCallBack", code);
-
-        //DotNet.invokeMethodAsync("ReactorBlazorQRCodeScanner", "QRCodeJsCallBackAsync", code);
     },
     Init: function () {
-        console.log("init jsQR");
+        try {
+            console.log("init jsQR");
+            videoStopped = false;
+            videoObject = document.createElement("video");
+            var canvasElement = document.getElementById("canvas");
+            var canvas = canvasElement.getContext("2d");
+            var loadingMessage = document.getElementById("loadingMessage");
+            var outputContainer = document.getElementById("output");
+            var outputMessage = document.getElementById("outputMessage");
+            var outputData = document.getElementById("outputData");
 
-        var video = document.createElement("video");
-        var canvasElement = document.getElementById("canvas");
-        var canvas = canvasElement.getContext("2d");
-        var loadingMessage = document.getElementById("loadingMessage");
-        var outputContainer = document.getElementById("output");
-        var outputMessage = document.getElementById("outputMessage");
-        var outputData = document.getElementById("outputData");
-
-        function drawLine(begin, end, color) {
-            canvas.beginPath();
-            canvas.moveTo(begin.x, begin.y);
-            canvas.lineTo(end.x, end.y);
-            canvas.lineWidth = 4;
-            canvas.strokeStyle = color;
-            canvas.stroke();
-        }
-
-        // Use facingMode: environment to attemt to get the front camera on phones
-        navigator.mediaDevices
-            .getUserMedia({ video: { facingMode: "environment" } })
-            .then(function (stream) {
-                video.srcObject = stream;
-                video.setAttribute("playsinline", true); // required to tell iOS safari we don't want fullscreen
-                video.play();
-                requestAnimationFrame(tick);
-            });
-
-        function tick() {
-            loadingMessage.innerText = " Loading video...";
-            if (video.readyState === video.HAVE_ENOUGH_DATA) {
-                loadingMessage.hidden = true;
-                canvasElement.hidden = false;
-                if (outputContainer)
-                    outputContainer.hidden = false;
-
-                canvasElement.height = video.videoHeight;
-                canvasElement.width = video.videoWidth;
-                canvas.drawImage(
-                    video,
-                    0,
-                    0,
-                    canvasElement.width,
-                    canvasElement.height
-                );
-                var imageData = canvas.getImageData(
-                    0,
-                    0,
-                    canvasElement.width,
-                    canvasElement.height
-                );
-                var code = jsQR(imageData.data, imageData.width, imageData.height, {
-                    inversionAttempts: "dontInvert",
-                });
-                if (code) {
-                    drawLine(
-                        code.location.topLeftCorner,
-                        code.location.topRightCorner,
-                        "#FF3B58"
-                    );
-                    drawLine(
-                        code.location.topRightCorner,
-                        code.location.bottomRightCorner,
-                        "#FF3B58"
-                    );
-                    drawLine(
-                        code.location.bottomRightCorner,
-                        code.location.bottomLeftCorner,
-                        "#FF3B58"
-                    );
-                    drawLine(
-                        code.location.bottomLeftCorner,
-                        code.location.topLeftCorner,
-                        "#FF3B58"
-                    );
-                    if (outputContainer) {
-                        outputMessage.hidden = true;
-                        outputData.parentElement.hidden = false;
-                        outputData.innerText = code.data;
-                    }
-
-                    Scanner.QRCodeScanned(code.data);
-
-                } else {
-                    //outputMessage.hidden = false;
-                    //outputData.parentElement.hidden = true;
-                }
+            function drawLine(begin, end, color) {
+                canvas.beginPath();
+                canvas.moveTo(begin.x, begin.y);
+                canvas.lineTo(end.x, end.y);
+                canvas.lineWidth = 4;
+                canvas.strokeStyle = color;
+                canvas.stroke();
             }
-            requestAnimationFrame(tick);
 
-            //console.log('requestAnimationFrame');
+            // Use facingMode: environment to attemt to get the front camera on phones
+            navigator.mediaDevices
+                .getUserMedia({ video: { facingMode: "environment" } })
+                .then(function (stream) {
+                    videoObject.srcObject = stream;
+                    videoObject.setAttribute("playsinline", true); // required to tell iOS safari we don't want fullscreen
+                    videoObject.play();
+                    requestAnimationFrame(tick);
+                });
+
+            function tick() {
+
+                if (videoStopped === true) // if the video has been stopped we don't have to execute the QR reading
+                    return;
+
+                if (videoObject.readyState === videoObject.HAVE_ENOUGH_DATA) {
+
+                    loadingMessage.hidden = true;
+                    canvasElement.hidden = false;
+                    if (outputContainer)
+                        outputContainer.hidden = false;
+
+                    canvasElement.height = videoObject.videoHeight;
+                    canvasElement.width = videoObject.videoWidth;
+                    canvas.drawImage(
+                        videoObject,
+                        0,
+                        0,
+                        canvasElement.width,
+                        canvasElement.height
+                    );
+                    var imageData = canvas.getImageData(
+                        0,
+                        0,
+                        canvasElement.width,
+                        canvasElement.height
+                    );
+                    var code = jsQR(imageData.data, imageData.width, imageData.height, {
+                        inversionAttempts: "dontInvert",
+                    });
+                    if (code) {
+                        drawLine(
+                            code.location.topLeftCorner,
+                            code.location.topRightCorner,
+                            "#FF3B58"
+                        );
+                        drawLine(
+                            code.location.topRightCorner,
+                            code.location.bottomRightCorner,
+                            "#FF3B58"
+                        );
+                        drawLine(
+                            code.location.bottomRightCorner,
+                            code.location.bottomLeftCorner,
+                            "#FF3B58"
+                        );
+                        drawLine(
+                            code.location.bottomLeftCorner,
+                            code.location.topLeftCorner,
+                            "#FF3B58"
+                        );
+                        if (outputContainer) {
+                            outputMessage.hidden = true;
+                            outputData.parentElement.hidden = false;
+                            outputData.innerText = code.data;
+                        }
+
+                        Scanner.QRCodeScanned(code.data);
+
+                    }
+                }
+                requestAnimationFrame(tick);
+            }
+
+        } catch (error) {
+            console.error(error);
         }
     },
+    Stop: function () {
+        try {
+            // if video object is null then we don't have to stop the stream
+            if (videoObject === null)
+                return;
+
+            if (videoObject.readyState === videoObject.HAVE_ENOUGH_DATA) {
+                videoStopped = true; // indicate that the video has been stopped to stop the requestAnimationFrame from ticking
+
+                const mediaStream = videoObject.srcObject;
+                const tracks = mediaStream.getTracks();
+                tracks.forEach(track => track.stop()) // stop the video stream(s)
+
+                // hide canvas
+                var canvasElement = document.getElementById("canvas");
+                if (canvasElement != null)
+                    canvasElement.hidden = true;
+
+                // clean up videoObject
+                videoObject = null;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+
+    },
+
 };
 
 export { Scanner };


### PR DESCRIPTION
- Added a new 'Stop' function is the JS library so that a user can stop the QR recording. This is particular useful when a user is done with the scanning and the browser won't keep showing the recording icon.
- Added parameters for the outputmessage and loadingmessage so that users can set these themselves.
- Cleaned up some (unnecessary) code bits.
- Translated some of the comments to English.
- Added Try-catch blocks in the JS library so that it becomes more clear if something goes wrong.
- Updated the ReadMe file and assembly number.
- Some typo's fixed.