### PR TITLE
Flip video feed horizontally

### DIFF
--- a/QRCodeScannerJsInterop.cs
+++ b/QRCodeScannerJsInterop.cs
@@ -18,22 +18,22 @@ namespace ReactorBlazorQRCodeScanner
                 "import", "./_content/ReactorBlazorQRCodeScanner/qrCodeScannerJsInterop.js").AsTask());
         }
 
-        public async ValueTask Init(Action<string> onQrCodeScanAction, bool useFrontCamera = false)
+        public async ValueTask Init(Action<string> onQrCodeScanAction, bool useFrontCamera = false, bool flipHorizontal = false)
         {
             _onQrCodeScanAction = onQrCodeScanAction;
 
             var module = await moduleTask.Value;
-            await module.InvokeVoidAsync("Scanner.Init", new object[1] { useFrontCamera });
+            await module.InvokeVoidAsync("Scanner.Init", new object[2] { useFrontCamera, flipHorizontal });
         }
 
         public async ValueTask Init(Action<string> onQrCodeScanAction, Action<string> onCameraPermissionFailedAction
-            , bool useFrontCamera = false)
+            , bool useFrontCamera = false, bool flipHorizontal = false)
         {
             _onQrCodeScanAction = onQrCodeScanAction;
             _onCameraPermissionFailedAction = onCameraPermissionFailedAction;
 
             var module = await moduleTask.Value;
-            await module.InvokeVoidAsync("Scanner.Init", new object[1] { useFrontCamera });
+            await module.InvokeVoidAsync("Scanner.Init", new object[2] { useFrontCamera, flipHorizontal });
         }
 
         public async ValueTask StopRecording()

--- a/wwwroot/qrCodeScannerJsInterop.js
+++ b/wwwroot/qrCodeScannerJsInterop.js
@@ -24,7 +24,7 @@ var Scanner = {
         //    DotNet.invokeMethodAsync("ReactorBlazorQRCodeScanner", "ManageErrorJsCallBack", json);
         //}
     },
-    Init: function (useFront) {
+    Init: function (useFront, flipHorizontal) {
         try {
             console.log("init jsQR");
             videoStopped = false;
@@ -44,6 +44,18 @@ var Scanner = {
                 canvas.lineWidth = 4;
                 canvas.strokeStyle = color;
                 canvas.stroke();
+            }
+
+            // function to assist flipping the borders of the QR code if the video is flipped
+            function transformLocationForFlipHorizontal(location) {
+                const transformPoint = ({ x, y }) => ({ x: canvasElement.width - x, y });
+                return {
+                    topLeftCorner: transformPoint(location.topLeftCorner),
+                    topRightCorner: transformPoint(location.topRightCorner),
+                    bottomRightCorner: transformPoint(location.bottomRightCorner),
+                    bottomLeftCorner: transformPoint(location.bottomLeftCorner)
+                };
+
             }
 
             // Use facingMode: environment to attemt to get the front camera on phones
@@ -83,7 +95,7 @@ var Scanner = {
                     var videoRatio = videoObject.videoWidth / videoObject.videoHeight;
                     var screenwidth = window.innerWidth;
                     var screenheight = window.innerHeight;
- 
+
                     if (!requestedWidth) {
                         //No requested size, original video size is displayed
                         canvasElement.width = videoObject.videoWidth;
@@ -91,17 +103,21 @@ var Scanner = {
                     }
                     else if (requestedWidth.includes('%')) {
                         //Width in % of the screen width size 
-                        var percent = parseInt(requestedWidth, 10);                                          
+                        var percent = parseInt(requestedWidth, 10);
                         canvasElement.width = screenwidth * percent / 100;
                         canvasElement.height = screenwidth * percent / 100 / videoRatio;
                     }
-                    else  {
+                    else {
                         //Width in pixel
                         canvasElement.width = requestedWidth;
                         canvasElement.height = requestedWidth / videoRatio;
-                    } 
+                    }
 
                     //### VIDEO SCREEN SIZE
+                    if (flipHorizontal) {
+                        canvas.translate(canvasElement.width, 0);
+                        canvas.scale(-1, 1);
+                    }
 
                     canvas.drawImage(
                         videoObject,
@@ -120,6 +136,9 @@ var Scanner = {
                         inversionAttempts: "dontInvert",
                     });
                     if (code) {
+                        if (flipHorizontal) {
+                            code.location = transformLocationForFlipHorizontal(code.location);
+                        }
                         drawLine(
                             code.location.topLeftCorner,
                             code.location.topRightCorner,


### PR DESCRIPTION
Added an extra option to flip the video feed horizontally.

Useful when holding QR code in front of a laptop or front facing camera (since it's hard to position a QR code otherwise)

It's simply an extra `bool` argument, `false` by default

```
protected override async Task OnInitializedAsync()
{
	_onQrCodeScanAction = (code) => OnQrCodeScan(code);

	_qrCodeScannerJsInterop = new QRCodeScannerJsInterop(JS);
	await _qrCodeScannerJsInterop.Init(_onQrCodeScanAction, false, true);
}
```